### PR TITLE
Pin Coqui TTS dependency to compatible version

### DIFF
--- a/app/services/model_installer.py
+++ b/app/services/model_installer.py
@@ -159,7 +159,7 @@ class ModelInstaller:
             or any(tag in tags for tag in {"xtts", "coqui"})
             or is_coqui_model(info)
         ):
-            requirements.add("TTS>=0.22.0")
+            requirements.add("TTS==0.22.0")
 
         if (
             library in {"kokoro", "kokoro-onnx"}


### PR DESCRIPTION
## Summary
- pin the Coqui TTS dependency requirement to version 0.22.0 to avoid incompatible newer releases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1af1f3330832b81acf1cab82e7328